### PR TITLE
top_success_imgをPCで非表示修正

### DIFF
--- a/src/css/common.scss
+++ b/src/css/common.scss
@@ -5,7 +5,7 @@
     display: none;
   }
   .top_success_img {
-    display: none;
+    display: none !important;
   }
 }
 


### PR DESCRIPTION
StaticImageにしたらcssが効かなくなったので効くように修正